### PR TITLE
Change use of `client_handshake` in oinq due to oinq version update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add more network data type. (`Ftp`)
 - Delete the policies by requested IDs.
 
+### Changed
+
+- Removes the `agent_id` provided in the config file. This value is provided by
+  the CN in the certificate in the form of `agent_id@host_id`.
+- Requires REview 0.22.x
+
 ## [0.1.0] - 2023-03-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "num_enum 0.6.1",
- "oinq 0.6.1",
+ "oinq",
  "quinn",
  "roxy",
  "rustls",
@@ -593,14 +593,14 @@ dependencies = [
 
 [[package]]
 name = "giganto-client"
-version = "0.5.0"
-source = "git+https://github.com/aicers/giganto-client.git?tag=0.5.0#68ed71ee4fb350806dbee76a4c4c8be89243b9a8"
+version = "0.7.0"
+source = "git+https://github.com/aicers/giganto-client.git?tag=0.7.0#fb7509ed9d3a20864b403608cb81c2b57fadfdd7"
 dependencies = [
  "anyhow",
  "bincode",
  "chrono",
  "num_enum 0.6.1",
- "oinq 0.6.0",
+ "oinq",
  "quinn",
  "semver",
  "serde",
@@ -1006,31 +1006,12 @@ dependencies = [
 
 [[package]]
 name = "oinq"
-version = "0.6.0"
-source = "git+https://github.com/petabi/oinq.git?tag=0.6.0#124e789623c169fd50fe7a159852104c504ae74a"
+version = "0.7.0"
+source = "git+https://github.com/petabi/oinq.git?tag=0.7.0#708871bda0bd80d73f732e33a6590fad78a69c22"
 dependencies = [
  "async-trait",
  "bincode",
  "futures",
- "gethostname",
- "ipnet",
- "num_enum 0.5.11",
- "quinn",
- "semver",
- "serde",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "oinq"
-version = "0.6.1"
-source = "git+https://github.com/petabi/oinq.git?tag=0.6.1#4cba4d0fb38a47ed91f3d7844765de9949f3b462"
-dependencies = [
- "async-trait",
- "bincode",
- "futures",
- "gethostname",
  "ipnet",
  "num_enum 0.6.1",
  "quinn",
@@ -1269,9 +1250,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.9.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445cbfe2382fa023c4f2f3c7e1c95c03dcc1df2bf23cebcb2b13e1402c4394d1"
+checksum = "21252f1c0fc131f1b69182db8f34837e8a69737b8251dff75636a9be0518c324"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -1282,14 +1263,13 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "webpki",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.9.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c10f662eee9c94ddd7135043e544f3c82fa839a1e7b865911331961b53186c"
+checksum = "85af4ed6ee5a89f26a26086e9089a6643650544c025158449a3626ebf72884b3"
 dependencies = [
  "bytes",
  "rand",
@@ -1301,20 +1281,19 @@ dependencies = [
  "thiserror",
  "tinyvec",
  "tracing",
- "webpki",
 ]
 
 [[package]]
 name = "quinn-udp"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
+checksum = "6df19e284d93757a9fb91d63672f7741b129246a669db09d1c0063071debc0c0"
 dependencies = [
+ "bytes",
  "libc",
- "quinn-proto",
- "socket2",
+ "socket2 0.5.2",
  "tracing",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1494,14 +1473,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
 dependencies = [
  "log",
  "ring",
+ "rustls-webpki",
  "sct",
- "webpki",
 ]
 
 [[package]]
@@ -1523,6 +1502,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1695,6 +1684,16 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d283f86695ae989d1e18440a943880967156325ba025f05049946bff47bcc2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1875,16 +1874,16 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "libc",
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -1933,6 +1932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2125,16 +2125,6 @@ checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ bincode = "1"
 chrono = { version = "0.4", features = ["serde"] }
 config = { version = "0.13", features = ["toml"], default-features = false }
 directories = "5.0"
-giganto-client = { git = "https://github.com/aicers/giganto-client.git", tag = "0.5.0" }
+giganto-client = { git = "https://github.com/aicers/giganto-client.git", tag = "0.7.0" }
 lazy_static = "1"
 num_enum = "0.6"
 num-traits = "0.2"
-oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.6.1" }
-quinn = "0.9"
+oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.7.0" }
+quinn = "0.10"
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.1.0" }
-rustls = "0.20"
+rustls = "0.21"
 rustls-pemfile = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Crusher generates statistics from raw events.
 
 ## Requirements
 
-* REview 0.18.0 or higher
-* Giganto 0.10.0 or higher
+* REview 0.22.0 or higher
+* Giganto 0.11.0 or higher
 
 ## Usage
 
@@ -31,8 +31,6 @@ The following is key values in the TOML configuration file.
 * `review_name`: the name of the review. This must match with the DNS name in
   the certificate.
 * `review_address`: IP address and port number of `review`.
-* `agent_id`: a unique identifier for the agent on the host where the agent is
-  running.
 * `last_timestamp_data`: File that stores the timestamp of the last time series
   per `sampling policy`.
 
@@ -47,7 +45,6 @@ giganto_ingestion_address = "127.0.0.1:38370"
 giganto_publish_address = "127.0.0.1:38371"
 review_name = "localhost"
 review_address ="127.0.0.1:38390"
-agent_id ="crusher"
 last_timestamp_data = "tests/time_data.json"
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,6 @@ async fn main() -> Result<()> {
     let request_client = request::Client::new(
         settings.review_address,
         settings.review_name,
-        settings.agent_id,
         cert.clone(),
         key.clone(),
         files.clone(),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,7 +8,6 @@ const DEFAULT_GIGANTO_INGESTION_ADDRESS: &str = "[::]:38370";
 const DEFAULT_GIGANTO_PUBLISH_ADDRESS: &str = "[::]:38371";
 const DEFAULT_REVIEW_NAME: &str = "localhost";
 const DEFAULT_REVIEW_ADDRESS: &str = "[::]:38390";
-const DEFAULT_AGENT_ID: &str = "cruhser";
 
 /// The application settings.
 #[derive(Clone, Debug, Deserialize)]
@@ -24,7 +23,6 @@ pub struct Settings {
     pub review_name: String,  // host name to review
     #[serde(deserialize_with = "deserialize_socket_addr")]
     pub review_address: SocketAddr, // IP address & port to review
-    pub agent_id: String,     //unique identifier
     pub last_timestamp_data: PathBuf, // Path to the last series timestamp data file
 }
 
@@ -85,8 +83,6 @@ fn default_config_builder() -> ConfigBuilder<DefaultState> {
         .expect("valid name")
         .set_default("review_address", DEFAULT_REVIEW_ADDRESS)
         .expect("valid address")
-        .set_default("agent_id", DEFAULT_AGENT_ID)
-        .expect("valid id")
         .set_default(
             "last_timestamp_data",
             last_timestamp_path.to_str().expect("path to string"),

--- a/src/subscribe.rs
+++ b/src/subscribe.rs
@@ -42,8 +42,8 @@ use tokio::{
 };
 use tracing::{error, info, trace, warn};
 
-const INGESTION_PROTOCOL_VERSION: &str = "0.10.0";
-const PUBLISH_PROTOCOL_VERSION: &str = "0.10.0";
+const INGESTION_PROTOCOL_VERSION: &str = "0.11.0";
+const PUBLISH_PROTOCOL_VERSION: &str = "0.11.0";
 const TIME_SERIES_CHANNEL_SIZE: usize = 1;
 const LAST_TIME_SERIES_TIMESTAMP_CHANNEL_SIZE: usize = 1;
 const SECOND_TO_NANO: i64 = 1_000_000_000;

--- a/src/subscribe/tests.rs
+++ b/src/subscribe/tests.rs
@@ -86,7 +86,7 @@ fn config_server() -> ServerConfig {
         }
     }
 
-    let client_auth = rustls::server::AllowAnyAuthenticatedClient::new(client_auth_roots);
+    let client_auth = rustls::server::AllowAnyAuthenticatedClient::new(client_auth_roots).boxed();
     let server_crypto = rustls::ServerConfig::builder()
         .with_safe_defaults()
         .with_client_cert_verifier(client_auth)

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -6,5 +6,4 @@
  giganto_publish_address = "127.0.0.1:38371"
  review_name = "localhost"
  review_address ="127.0.0.1:38390"
- agent_id ="crusher"
  last_timestamp_data = "tests/time_data.json"


### PR DESCRIPTION
- Removes the agent_id provided by the argument. This value is provided by the certificate.
- Update quinn version to 0.10 and rustls version to 0.21 for giganto-client version to 0.7.0.
- Update review version to 0.22.0.