### PR TITLE
Modify policy interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Change the `Interval`/`RequestedInterval` enum to include the new fields.
+  (FifteenSeconds,ThirtySeconds,OneMinutes)
+
 ## [0.3.1] - 2023-11-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "crusher"
-version = "0.3.1"
+version = "0.3.1+rio.0.0.1"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crusher"
-version = "0.3.1"
+version = "0.3.1+rio.0.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,7 +15,7 @@ pub fn config(certs: Vec<Certificate>, key: PrivateKey, files: Vec<Vec<u8>>) -> 
             .into_iter()
             .map(rustls::Certificate)
             .collect();
-        if let Some(cert) = root_cert.get(0) {
+        if let Some(cert) = root_cert.first() {
             root_store.add(cert)?;
         }
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -14,6 +14,9 @@ use std::net::IpAddr;
 #[derive(Clone, Copy, IntoPrimitive, Deserialize, Debug)]
 #[repr(u32)]
 pub enum Interval {
+    FifteenSeconds = 15,
+    ThirtySeconds = 30,
+    OneMinutes = 60,
     FiveMinutes = 300,
     TenMinutes = 600,
     FifteenMinutes = 900,
@@ -24,6 +27,9 @@ pub enum Interval {
 impl From<RequestedInterval> for Interval {
     fn from(i: RequestedInterval) -> Self {
         match i {
+            RequestedInterval::FifteenSeconds => Self::FifteenSeconds,
+            RequestedInterval::ThirtySeconds => Self::ThirtySeconds,
+            RequestedInterval::OneMinutes => Self::OneMinutes,
             RequestedInterval::FiveMinutes => Self::FiveMinutes,
             RequestedInterval::TenMinutes => Self::TenMinutes,
             RequestedInterval::FifteenMinutes => Self::FifteenMinutes,

--- a/src/request.rs
+++ b/src/request.rs
@@ -58,11 +58,14 @@ pub enum RequestedKind {
 #[derive(Debug, Deserialize, TryFromPrimitive, Clone)]
 #[repr(u32)]
 pub enum RequestedInterval {
-    FiveMinutes = 0,
-    TenMinutes = 1,
-    FifteenMinutes = 2,
-    ThirtyMinutes = 3,
-    OneHour = 4,
+    FifteenSeconds = 0,
+    ThirtySeconds = 1,
+    OneMinutes = 2,
+    FiveMinutes = 3,
+    TenMinutes = 4,
+    FifteenMinutes = 5,
+    ThirtyMinutes = 6,
+    OneHour = 7,
 }
 
 #[derive(Debug, Deserialize, TryFromPrimitive, Clone)]

--- a/src/subscribe.rs
+++ b/src/subscribe.rs
@@ -481,7 +481,7 @@ async fn publish_connect(
 async fn calculate_series_start_time(req_pol: &RequestedPolicy) -> Result<i64> {
     let mut start: i64 = 0;
     if let Some(last_time) = LAST_TRANSFER_TIME.read().await.get(&req_pol.id.to_string()) {
-        let Some(period) = u32::from(Period::try_from(req_pol.period.clone())?).to_i64() else {
+        let Some(period) = u32::from(Period::from(req_pol.period.clone())).to_i64() else {
             bail!("Failed to convert period");
         };
         let Some(period_nano) = period.checked_mul(SECOND_TO_NANO) else {


### PR DESCRIPTION
This PR is for a feature that is only used in rio projects.
- Change the `Interval`/`RequestedInterval` enum to include the new fields.
- Fix clippy error.
- Bump the new rio version 0.3.1+rio.0.0.1.