### PR TITLE
Refactor dependencies to use review-protocol crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,8 +297,8 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "num_enum",
- "oinq",
  "quinn",
+ "review-protocol",
  "roxy",
  "rustls",
  "rustls-pemfile",
@@ -1291,6 +1291,17 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "review-protocol"
+version = "0.1.1"
+source = "git+https://github.com/petabi/review-protocol.git?tag=0.1.1#311b3fd73026071d2ffb6d80530d276dd7989ddf"
+dependencies = [
+ "anyhow",
+ "oinq",
+ "quinn",
+ "serde",
+]
 
 [[package]]
 name = "ring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,10 @@ giganto-client = { git = "https://github.com/aicers/giganto-client.git", tag = "
 lazy_static = "1"
 num_enum = "0.7"
 num-traits = "0.2"
-oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.10.0" }
 quinn = "0.10"
+review-protocol = { git = "https://github.com/petabi/review-protocol.git", features = [
+    "client",
+], tag = "0.1.1" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = "0.21"
 rustls-pemfile = "1.0"

--- a/src/request.rs
+++ b/src/request.rs
@@ -4,8 +4,8 @@ use async_channel::Sender;
 use async_trait::async_trait;
 use bincode::Options;
 use num_enum::TryFromPrimitive;
-use oinq::{request, Config};
 use quinn::{Connection, ConnectionError, Endpoint, RecvStream, SendStream, VarInt};
+use review_protocol::{request, types as protocol_types, HandshakeError};
 use rustls::{Certificate, PrivateKey};
 use serde::Deserialize;
 use std::{
@@ -197,8 +197,8 @@ async fn connect(
 async fn handshake(
     conn: &Connection,
     protocol: &str,
-) -> Result<(SendStream, RecvStream), oinq::message::HandshakeError> {
-    let (send, recv) = oinq::message::client_handshake(
+) -> Result<(SendStream, RecvStream), HandshakeError> {
+    let (send, recv) = review_protocol::client::handshake(
         conn,
         env!("CARGO_PKG_NAME"),
         env!("CARGO_PKG_VERSION"),
@@ -213,9 +213,9 @@ async fn handle_incoming(handler: RequestHandler, conn: &Connection) -> Result<(
         match conn.accept_bi().await {
             Ok((mut send, mut recv)) => {
                 let mut hdl = handler.clone();
-                tokio::spawn(
-                    async move { oinq::request::handle(&mut hdl, &mut send, &mut recv).await },
-                );
+                tokio::spawn(async move {
+                    review_protocol::request::handle(&mut hdl, &mut send, &mut recv).await
+                });
             }
             Err(e) => {
                 conn.close(VarInt::from_u32(0), b"Lost server connection");
@@ -234,7 +234,7 @@ struct RequestHandler {
 }
 
 #[async_trait]
-impl oinq::request::Handler for RequestHandler {
+impl review_protocol::request::Handler for RequestHandler {
     async fn reboot(&mut self) -> Result<(), String> {
         for attempt in 1..=MAX_RETRIES {
             if let Err(e) = roxy::reboot() {
@@ -263,9 +263,9 @@ impl oinq::request::Handler for RequestHandler {
         Err(String::from("cannot shutdown the system"))
     }
 
-    async fn resource_usage(&mut self) -> Result<(String, oinq::ResourceUsage), String> {
+    async fn resource_usage(&mut self) -> Result<(String, protocol_types::ResourceUsage), String> {
         let usg = roxy::resource_usage().await;
-        let usg = oinq::ResourceUsage {
+        let usg = protocol_types::ResourceUsage {
             cpu_usage: usg.cpu_usage,
             total_memory: usg.total_memory,
             used_memory: usg.used_memory,
@@ -324,7 +324,7 @@ impl oinq::request::Handler for RequestHandler {
         Ok(())
     }
 
-    async fn get_config(&mut self) -> Result<Config, String> {
+    async fn get_config(&mut self) -> Result<protocol_types::Config, String> {
         for attempt in 1..=MAX_RETRIES {
             match crate::settings::get_config() {
                 Ok(conf) => return Ok(conf),
@@ -339,7 +339,7 @@ impl oinq::request::Handler for RequestHandler {
         Err(String::from("failed to get config"))
     }
 
-    async fn set_config(&mut self, conf: Config) -> Result<(), String> {
+    async fn set_config(&mut self, conf: protocol_types::Config) -> Result<(), String> {
         info!("start set configuration");
         for attempt in 1..=MAX_RETRIES {
             if let Err(e) = crate::settings::set_config(&conf) {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,7 +1,7 @@
 //! Configurations for the application.
 use anyhow::{Context, Result};
 use config::{builder::DefaultState, Config as cfg, ConfigBuilder, ConfigError, File};
-use oinq::{request::CrusherConfig, Config};
+use review_protocol::types::{Config, CrusherConfig};
 use serde::{de::Error, Deserialize, Deserializer};
 use std::{
     fs::{self, OpenOptions},


### PR DESCRIPTION
This pull request addresses the issue in `oinq` regarding its structure and modularity, as described in petabi/oinq#60. Currently, `oinq` serves as a comprehensive package for implementing the communication protocol within the REview ecosystem, relying on QUIC for efficient and secure communication. However, to promote code reuse and collaboration among projects utilizing QUIC, it's proposed to refactor `oinq` into two separate crates:

1. **`oinq`**: This crate will focus solely on low-level network communication, such as sending and receiving messages and streams.
2. **`review-protocol`**: Built on top of `oinq`, this crate will implement the application-specific protocol for the REview ecosystem.

This pull request implements the proposed changes by replacing direct dependencies on `oinq` within Crusher with dependencies on `review-protocol` where necessary. Specifically, the changes include modifying import paths, function calls, and types to align with the new crate structure.

## Changes Made

- Updated import paths to use types and functions from `review_protocol` instead of `oinq`.
- Replaced direct dependencies on `oinq` with dependencies on `review-protocol`.

**Note**: There's no functional change caused by this PR. The functionality remains intact, and the modifications solely pertain to dependency management and code organization.
