### PR TITLE
bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Apply Group imports by StdExternalCrate.
-  - Modify the code with this command:
-    - `cargo fmt -- --config group_imports=StdExternalCrate`.
-  - Add `--config group_imports=StdExternalCrate` to the CI process like:
-    - `cargo fmt -- --check --config group_imports=StdExternalCrate`
+- Applied code import ordering by `StdExternalCrate`. From now on, all code is
+  expected to be formatted using `cargo fmt -- --config group_imports=StdExternalCrate`.
 - Changed CrusherConfig with oinq `Config`.
 - Modified logging behavior for debug and release builds
 - Changed logs to stdout and file
@@ -33,15 +30,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - `giganto_ingest_address` to `giganto_ingest_srv_addr`.
   - `giganto_publish_address` to `giganto_publish_srv_addr`.
   - `review_address` to `review_rpc_srv_addr`.
-- Updated giganto-client to version `0.17.0`. Updating to this version results
+- Updated giganto-client to version "0.20.0". Updating to this version results
   in the following changes.
-  - Bump dependencies.
-    - Update quinn to version `0.11`.
-    - Update rustls to version `0.23`.
-    - Update review-protocol to version `0.3`.
-  - Update the protocol version of the giganto ingest, publish module.
-    - Changed `PUBLISH_PROTOCOL_VERSION` to "0.21.0-alpha.1"
-    - Changed `INGEST_PROTOCOL_VERSION` to "0.21.0-alpha.1"
+  - Updated the version of quinn, rustls from 0.10, 0.21 to 0.11, 0.23. With the
+    update to this version, the usage of the quinn and rustls crates has
+    changed, so code affected by the update has also been modified.
+  - Updated the protocol version of the review, giganto.
+    - Changed `REVIEW_PROTOCOL_VERSION` to "0.38.0".
+    - Changed `PUBLISH_PROTOCOL_VERSION` to "0.21.0".
+    - Changed `INGEST_PROTOCOL_VERSION` to "0.21.0".
+  - Added more network data type. (`Bootp`, `Dhcp`)
 - Changed the form of timeseries sent to giganto to `Vec<(i64,Vec<u8>)>`.
   Currently, giganto has changed to send and receive a certain number of
   events at once to optimize sending and receiving large amounts of data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   For timeseries, one event is generated per period, and it takes too long
   to collect and send a certain number of timeseries events, so it was
   changed to send only one event as a vector.
+- Updated review-protocol to version 0.6.0.
+  - Modified to use `ConnectionBuilder` to simplify the handling of connections
+    with Central Manager.
+  - As `set_config` was removed from `review-protocol::request::handler`,
+    Removed the `set_config` related code from the crusher.
 
 ## [0.3.2] - 2024-01-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,16 +1298,17 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "review-protocol"
-version = "0.3.0"
-source = "git+https://github.com/petabi/review-protocol.git?tag=0.3.0#25f110bb751b0c66df1dbbaf77e48985afb57eb3"
+version = "0.6.0"
+source = "git+https://github.com/petabi/review-protocol.git?tag=0.6.0#6cd6b9a404fadc83980d813fcd3a38bf6b7b5253"
 dependencies = [
- "anyhow",
  "async-trait",
  "bincode",
  "ipnet",
  "num_enum",
  "oinq",
  "quinn",
+ "rustls",
+ "rustls-pemfile",
  "semver",
  "serde",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,8 +561,8 @@ dependencies = [
 
 [[package]]
 name = "giganto-client"
-version = "0.17.0"
-source = "git+https://github.com/aicers/giganto-client.git?tag=0.17.0#9747b0330e19b2b57c27d26eefa12884a8922c79"
+version = "0.20.0"
+source = "git+https://github.com/aicers/giganto-client.git?tag=0.20.0#d38bc68469ef1d64e4e5d49dd0b5ca20aec4d30b"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ bincode = "1"
 chrono = { version = "0.4", features = ["serde"] }
 config = { version = "0.14", features = ["toml"], default-features = false }
 directories = "5.0"
-giganto-client = { git = "https://github.com/aicers/giganto-client.git", tag = "0.17.0" }
+giganto-client = { git = "https://github.com/aicers/giganto-client.git", tag = "0.20.0" }
 num_enum = "0.7"
 num-traits = "0.2"
 quinn = { version = "0.11", features = ["ring"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ num-traits = "0.2"
 quinn = { version = "0.11", features = ["ring"] }
 review-protocol = { git = "https://github.com/petabi/review-protocol.git", features = [
     "client",
-], tag = "0.3.0" }
+], tag = "0.6.0" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = { version = "0.23", default-features = false, features = [
     "ring",

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Crusher generates statistics from raw events.
 
 ## Requirements
 
-* REview 0.33.0 or higher
-* Giganto 0.17.0 or higher
+* REview 0.38.0 or higher
+* Giganto 0.21.0 or higher
 
 ## Usage
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -25,7 +25,7 @@ use crate::{
     TEMP_TOML_POST_FIX,
 };
 
-const REVIEW_PROTOCOL_VERSION: &str = "0.27.0";
+const REVIEW_PROTOCOL_VERSION: &str = "0.38.0";
 const MAX_RETRIES: u8 = 3;
 
 #[derive(Debug, Deserialize, Clone)]
@@ -59,6 +59,8 @@ pub enum RequestedKind {
     Tls = 12,
     Smb = 13,
     Nfs = 14,
+    Bootp = 15,
+    Dhcp = 16,
 }
 
 #[derive(Debug, Deserialize, TryFromPrimitive, Clone)]

--- a/src/subscribe/tests.rs
+++ b/src/subscribe/tests.rs
@@ -113,8 +113,8 @@ fn cert_key() -> Certs {
     let cert = to_cert_chain(&cert_pem).unwrap();
     let key_pem = fs::read(KEY_PATH).unwrap();
     let key = to_private_key(&key_pem).unwrap();
-    let ca_certs_paths = vec![PathBuf::from(CA_CERT_PATH)];
-    let ca_certs = to_ca_certs(&ca_certs_paths).unwrap();
+    let ca_certs_pem = vec![fs::read(CA_CERT_PATH).unwrap()];
+    let ca_certs = to_ca_certs(&ca_certs_pem).unwrap();
 
     Certs {
         certs: cert.clone(),

--- a/src/subscribe/tests.rs
+++ b/src/subscribe/tests.rs
@@ -196,6 +196,8 @@ fn gen_conn() -> Conn {
         resp_bytes: 295,
         orig_pkts: 397,
         resp_pkts: 511,
+        orig_l2_bytes: 51235,
+        resp_l2_bytes: 48203,
     }
 }
 


### PR DESCRIPTION
1. Update giganto-client to 0.20.0
- Add more network data type. (`Bootp`, `Dhcp`)
- Update the protocol version of the REview, giganto.
   - Change `REVIEW_PROTOCOL_VERSION` to "0.38.0".
   - Change `PUBLISH_PROTOCOL_VERSION` to "0.21.0".
   - Change `INGEST_PROTOCOL_VERSION` to "0.21.0".

2. Update review-protocol version to 0.6.0
- Modify to use `ConnectionBuilder` to simplify the handling of connections with Central Manager.
- As `set_config` was removed from `review-protocol::request::handler`, Remove the `set_config` 
  related code from the crusher.

    
Close: #96
Close: #98