### PR TITLE
Update REview handshake compatible version & review-protocol version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Changed `REVIEW_PROTOCOL_VERSION` to "0.39.0"
+- Updated review-protocol to version "0.7.0".
+  - As `get_config` was removed from `review-protocol::request::handler`,
+    Removed the `get_config` related code from the crusher.
+
 ## [0.4.0] - 2024-09-27
 
 ### Added
@@ -41,7 +50,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   For timeseries, one event is generated per period, and it takes too long
   to collect and send a certain number of timeseries events, so it was
   changed to send only one event as a vector.
-- Updated review-protocol to version 0.6.0.
+- Updated review-protocol to version "0.6.0".
   - Modified to use `ConnectionBuilder` to simplify the handling of connections
     with Central Manager.
   - As `set_config` was removed from `review-protocol::request::handler`,
@@ -92,6 +101,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Send the generated `time series` to `giganto`'s ingest.
 - Save the model's id and the last time the timeseries was sent to a file.
 
+[Unreleased]: https://github.com/aicers/crusher/compare/0.4.0...main
 [0.4.0]: https://github.com/aicers/crusher/compare/0.3.2...0.4.0
 [0.3.2]: https://github.com/aicers/crusher/compare/0.3.1...0.3.2
 [0.3.1]: https://github.com/aicers/crusher/compare/0.3.0...0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,8 +1301,8 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "review-protocol"
-version = "0.6.0"
-source = "git+https://github.com/petabi/review-protocol.git?tag=0.6.0#6cd6b9a404fadc83980d813fcd3a38bf6b7b5253"
+version = "0.7.0"
+source = "git+https://github.com/petabi/review-protocol.git?tag=0.7.0#b99317dd77c89836c21df9368494e9bf12b7d749"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1314,6 +1314,7 @@ dependencies = [
  "rustls-pemfile",
  "semver",
  "serde",
+ "serde_repr",
  "thiserror",
 ]
 
@@ -1552,6 +1553,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ num-traits = "0.2"
 quinn = { version = "0.11", features = ["ring"] }
 review-protocol = { git = "https://github.com/petabi/review-protocol.git", features = [
     "client",
-], tag = "0.6.0" }
+], tag = "0.7.0" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = { version = "0.23", default-features = false, features = [
     "ring",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Crusher generates statistics from raw events.
 
 ## Requirements
 
-* REview 0.38.0 or higher
+* REview 0.39.0 or higher
 * Giganto 0.21.0 or higher
 
 ## Usage

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,6 @@ async fn main() -> Result<()> {
             Arc::clone(&delete_policy_ids),
             config_reload.clone(),
             notify_shutdown.clone(),
-            config_path.clone(),
         ));
 
         let subscribe_client = subscribe::Client::new(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,15 +1,9 @@
 //! Configurations for the application.
-use std::{
-    fs::{self},
-    net::SocketAddr,
-    path::PathBuf,
-};
+use std::{net::SocketAddr, path::PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use config::{builder::DefaultState, Config as cfg, ConfigBuilder, ConfigError, File};
-use review_protocol::types::{Config, CrusherConfig};
 use serde::{de::Error, Deserialize, Deserializer};
-use toml_edit::DocumentMut;
 
 const DEFAULT_GIGANTO_NAME: &str = "localhost";
 const DEFAULT_GIGANTO_INGEST_SRV_ADDR: &str = "[::]:38370";
@@ -109,27 +103,4 @@ where
     let addr = String::deserialize(deserializer)?;
     addr.parse()
         .map_err(|e| D::Error::custom(format!("invalid address \"{addr}\": {e}")))
-}
-
-pub fn get_config(config_path: &str) -> Result<Config> {
-    let toml = fs::read_to_string(config_path).context("toml not found")?;
-    let doc = toml.parse::<DocumentMut>()?;
-
-    let giganto_publish_srv_addr = doc
-        .get("giganto_publish_srv_addr")
-        .context("\"giganto_publish_srv_addr\" not found")?
-        .to_string()
-        .trim_matches('\"')
-        .parse::<SocketAddr>()?;
-    let giganto_ingest_srv_addr = doc
-        .get("giganto_ingest_srv_addr")
-        .context("\"giganto_ingest_srv_addr\" not found")?
-        .to_string()
-        .trim_matches('\"')
-        .parse::<SocketAddr>()?;
-
-    Ok(Config::Crusher(CrusherConfig {
-        giganto_publish_address: Some(giganto_publish_srv_addr),
-        giganto_ingest_address: Some(giganto_ingest_srv_addr),
-    }))
 }


### PR DESCRIPTION
- Changed `REVIEW_PROTOCOL_VERSION` to "0.39.0"
- Updated review-protocol to version "0.7.0".
  - As `get_config` was removed from `review-protocol::request::handler`, Removed the `get_config` related code from the crusher.

Close: #101