### PR TITLE
Correct how to refer to other required modules in the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Changed `REVIEW_PROTOCOL_VERSION` to "0.39.0"
+- Correct how to refer to other required modules in the code.
+  - Changed `REVIEW_PROTOCOL_VERSION` to `REQUIRED_MANAGER_VERSION`.
+  - Used `REQUIRED_GIGANTO_VERSION` instead of names that include `INGEST` or `PUBLISH`.
+- Changed `REQUIRED_MANAGER_VERSION` to "0.39.0"
 - Updated review-protocol to version "0.7.0".
   - As `get_config` was removed from `review-protocol::request::handler`,
     Removed the `get_config` related code from the crusher.

--- a/src/request.rs
+++ b/src/request.rs
@@ -24,7 +24,7 @@ use tracing::{error, info, trace, warn};
 
 use crate::client::SERVER_RETRY_INTERVAL;
 
-const REVIEW_PROTOCOL_VERSION: &str = "0.39.0";
+const REQUIRED_MANAGER_VERSION: &str = "0.39.0";
 const MAX_RETRIES: u8 = 3;
 
 #[derive(Debug, Deserialize, Clone)]
@@ -166,7 +166,7 @@ async fn connect(
         client.server_address,
         env!("CARGO_PKG_NAME"),
         env!("CARGO_PKG_VERSION"),
-        REVIEW_PROTOCOL_VERSION,
+        REQUIRED_MANAGER_VERSION,
         &client.cert,
         &client.key,
     )?;

--- a/src/subscribe.rs
+++ b/src/subscribe.rs
@@ -47,8 +47,7 @@ use crate::{
     request::{RequestedKind, RequestedPolicy},
 };
 
-const INGEST_PROTOCOL_VERSION: &str = "0.21.0";
-const PUBLISH_PROTOCOL_VERSION: &str = "0.21.0";
+const REQUIRED_GIGANTO_VERSION: &str = "0.21.0";
 const TIME_SERIES_CHANNEL_SIZE: usize = 1;
 const LAST_TIME_SERIES_TIMESTAMP_CHANNEL_SIZE: usize = 1;
 const SECOND_TO_NANO: i64 = 1_000_000_000;
@@ -226,7 +225,7 @@ impl Client {
                 self.endpoint.clone(),
                 wait_shutdown.clone(),
                 self.last_series_time_path.clone(),
-                INGEST_PROTOCOL_VERSION,
+                REQUIRED_GIGANTO_VERSION,
             ),
             publish_connection_control(
                 sender,
@@ -234,7 +233,7 @@ impl Client {
                 &self.server_name,
                 &self.endpoint,
                 wait_shutdown.clone(),
-                PUBLISH_PROTOCOL_VERSION,
+                REQUIRED_GIGANTO_VERSION,
                 &self.request_recv,
                 active_policy_list,
                 delete_policy_ids,


### PR DESCRIPTION
- Changed `REVIEW_PROTOCOL_VERSION` to `REQUIRED_MANAGER_VERSION`.
- Used `REQUIRED_GIGANTO_VERSION` instead of names that include `INGEST` or `PUBLISH`.

Close: #105