### PR TITLE
[WIP] Update configuration from Manager server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Replaced `reload_config` request handler with `update_config`.
+
 ## [0.5.0] - 2024-11-26
 
 ### Changed
@@ -135,6 +141,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Send the generated `time series` to `giganto`'s ingest.
 - Save the model's id and the last time the timeseries was sent to a file.
 
+[Unreleased]: https://github.com/aicers/crusher/compare/0.5.0...main
 [0.5.0]: https://github.com/aicers/crusher/compare/0.4.1...0.5.0
 [0.4.1]: https://github.com/aicers/crusher/compare/0.4.0...0.4.1
 [0.4.0]: https://github.com/aicers/crusher/compare/0.3.2...0.4.0

--- a/src/request.rs
+++ b/src/request.rs
@@ -305,8 +305,8 @@ impl review_protocol::request::Handler for RequestHandler {
         Ok(())
     }
 
-    async fn reload_config(&mut self) -> Result<(), String> {
-        info!("start reloading configuration");
+    async fn update_config(&mut self) -> Result<(), String> {
+        info!("Updating configuration");
         self.config_reload.notify_one();
         Ok(())
     }


### PR DESCRIPTION
Replace `reload_config` with `update_config`.

Close: #112 

<del>
In this version, the `update_config` is effectively dead code (non-functional) because:

- if a local config is provided, the updated config is ignored by policy.
- if no local config is provided, the program cannot run normally due to the absence of `last_timestamp_data`.

As discussed, this will be addressed in a separate issue as follows:
- If no local config is provided, retrieve the config from the Manager server.
- If all attempts fail, the program will enter minimal mode.

# About code details

1. There are code patterns like `writer.lock().unwrap_or_else(std::sync::PoisonError::into_inner)` 
which ignore the `PoisonError`, assuming that the log writer should not cause a
panic even if another thread has poisoned the lock.

2. If `log_dir` changes by updating config, logs should be saved in that
directory. This commit implements this by wrapping the file writer.
Alternatively, `tracing_subscriber::reload` could be used, but it cannot
handle cases where the directory is added or removed (as it requires
reassigning the writer itself, which is not possible due to internal
limitations).
Related issue: https://github.com/tokio-rs/tracing/issues/1629
</del>
