### PR TITLE
Remove redundant `clone` call

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -72,7 +72,7 @@ pub enum RequestedInterval {
     OneHour = 4,
 }
 
-#[derive(Debug, Deserialize, TryFromPrimitive, Clone)]
+#[derive(Clone, Copy, Debug, Deserialize, TryFromPrimitive)]
 #[repr(u32)]
 pub enum RequestedPeriod {
     SixHours,

--- a/src/subscribe.rs
+++ b/src/subscribe.rs
@@ -483,7 +483,7 @@ async fn publish_connect(
 async fn calculate_series_start_time(req_pol: &RequestedPolicy) -> Result<i64> {
     let mut start: i64 = 0;
     if let Some(last_time) = LAST_TRANSFER_TIME.read().await.get(&req_pol.id.to_string()) {
-        let Some(period) = u32::from(Period::from(req_pol.period.clone())).to_i64() else {
+        let Some(period) = u32::from(Period::from(req_pol.period)).to_i64() else {
             bail!("Failed to convert period");
         };
         let Some(period_nano) = period.checked_mul(SECOND_TO_NANO) else {


### PR DESCRIPTION
This PR removes unnecessary `clone` calls in `src/subscribe.rs`. The `RequestedPeriod` enum now derives `Copy`, making the `clone` call in `calculate_series_start_time` redundant. 