### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2024-11-26
 
 ### Changed
 
@@ -26,9 +26,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   be created, logs will be printed to stdout.
 - Changed `source` to `sensor`, which is a more appropriate term for the name of
   the device that sensed/captured the raw event.
-- Updated the protocol version of the review, giganto.
-  - Changed `REQUIRED_MANAGER_VERSION` to "0.41.0".
-  - Changed `REQUIRED_GIGANTO_VERSION` to "0.23.0".
+- Changed `REQUIRED_GIGANTO_VERSION` to "0.23.0".
 
 ### Removed
 
@@ -137,7 +135,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Send the generated `time series` to `giganto`'s ingest.
 - Save the model's id and the last time the timeseries was sent to a file.
 
-[Unreleased]: https://github.com/aicers/crusher/compare/0.4.1...main
+[0.5.0]: https://github.com/aicers/crusher/compare/0.4.1...0.5.0
 [0.4.1]: https://github.com/aicers/crusher/compare/0.4.0...0.4.1
 [0.4.0]: https://github.com/aicers/crusher/compare/0.3.2...0.4.0
 [0.3.2]: https://github.com/aicers/crusher/compare/0.3.1...0.3.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,45 +97,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
-name = "asn1-rs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
-dependencies = [
- "asn1-rs-derive",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "asn1-rs-impl"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-channel"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,7 +350,7 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crusher"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -409,11 +370,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml_edit",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "x509-parser",
 ]
 
 [[package]]
@@ -458,20 +417,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
-name = "der-parser"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
-dependencies = [
- "asn1-rs",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,17 +424,6 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1019,15 +953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oid-registry"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
-dependencies = [
- "asn1-rs",
-]
-
-[[package]]
 name = "oinq"
 version = "0.13.0"
 source = "git+https://github.com/petabi/oinq.git?tag=0.13.0#c48b3dbafedb7df3bc595ddea15a5c96bae00b2e"
@@ -1438,15 +1363,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
-name = "rusticata-macros"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "rustls"
 version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1789,17 +1705,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2417,23 +2322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "x509-parser"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
-dependencies = [
- "asn1-rs",
- "data-encoding",
- "der-parser",
- "lazy_static",
- "nom",
- "oid-registry",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crusher"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -28,9 +28,7 @@ rustls = { version = "0.23", default-features = false, features = [
 rustls-pemfile = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-toml_edit = "0.22"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = "0.3"
-x509-parser = "0.16"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Crusher generates statistics from raw events.
 ## Requirements
 
 - REview 0.39.0 or higher
-- Giganto 0.21.0 or higher
+- Giganto 0.23.0 or higher
 
 ## Usage
 
@@ -38,7 +38,8 @@ In these commands:
   specified by repeating the `--ca-certs` option.
 - `<SERVER_NAME>` is the name of the Manager server, and
   `<SERVER_IP>:<SERVER_PORT>` is the IP address and port number of the Manager
-  server. Ensure that `<SERVER_NAME>` matches the DNS name specified in the certificate.
+  server. Ensure that `<SERVER_NAME>` matches the DNS name specified in the
+  certificate.
 
 ## Example
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -24,7 +24,7 @@ use tracing::{error, info, trace, warn};
 
 use crate::client::SERVER_RETRY_INTERVAL;
 
-const REQUIRED_MANAGER_VERSION: &str = "0.41.0";
+const REQUIRED_MANAGER_VERSION: &str = "0.39.0";
 const MAX_RETRIES: u8 = 3;
 
 #[derive(Debug, Deserialize, Clone)]


### PR DESCRIPTION
- Change `REQUIRED_MANAGER_VERSION` to 0.39.0 because the version for quic communication with the manager server is 0.39.0.

Related issue: #122