### PR TITLE
Remove unnecessary Arc usage for Certs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,7 @@ impl Clone for Certs {
     }
 }
 
-pub fn config(certs: &Arc<Certs>) -> Result<Endpoint> {
+pub fn config(certs: &Certs) -> Result<Endpoint> {
     let tls_config = rustls::ClientConfig::builder()
         .with_root_certificates(certs.ca_certs.clone())
         .with_client_auth_cert(certs.certs.clone(), certs.key.clone_key())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,11 +110,11 @@ async fn main() -> Result<()> {
             ca_certs_pem.push(file);
         }
         let ca_certs = to_ca_certs(&ca_certs_pem).context("failed to read CA certificates")?;
-        let certs = Arc::new(Certs {
+        let certs = Certs {
             certs: cert.clone(),
             key: key.clone_key(),
             ca_certs: ca_certs.clone(),
-        });
+        };
 
         read_last_timestamp(&settings.last_timestamp_data).await?;
 

--- a/src/subscribe.rs
+++ b/src/subscribe.rs
@@ -195,7 +195,7 @@ impl Client {
         publish_addr: SocketAddr,
         server_name: String,
         last_series_time_path: PathBuf,
-        certs: &Arc<Certs>,
+        certs: &Certs,
         request_recv: Receiver<RequestedPolicy>,
     ) -> Self {
         let endpoint =

--- a/src/subscribe/tests.rs
+++ b/src/subscribe/tests.rs
@@ -103,7 +103,7 @@ fn client() -> Client {
         SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), TEST_PUBLISH_PORT),
         String::from(HOST),
         PathBuf::from(LAST_TIME_SERIES_PATH),
-        &Arc::new(certs),
+        &certs,
         rx,
     )
 }


### PR DESCRIPTION
The `Certs` struct is not shared across threads, so the `Arc` is not needed.