### PR TITLE
Send the agent status to the Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Updated review-protocol to version "07edf4d" (hash).
+- Changed `REQUIRED_MANAGER_VERSION` to 0.42.0.
+- Updated review-protocol to version 0.9.0.
+  - Send the agent status to the manager.
   - Updated the signatures of `sampling_policy_list`, `delete_sampling_policy`.
   - Replaced the `RequestedPolicy`, `Policy` structs with the `SamplingPolicy`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,8 +1290,8 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "review-protocol"
-version = "0.8.1"
-source = "git+https://github.com/petabi/review-protocol.git?rev=07edf4d#07edf4dd23b8685a7d29a27510d3598898fc7d24"
+version = "0.9.0"
+source = "git+https://github.com/petabi/review-protocol.git?tag=0.9.0#4028bc484fe8f39ef8200540d28300d6b5788927"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1304,7 +1304,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_repr",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ num-traits = "0.2"
 quinn = { version = "0.11", features = ["ring"] }
 review-protocol = { git = "https://github.com/petabi/review-protocol.git", features = [
     "client",
-], rev = "07edf4d" }
+], tag = "0.9.0" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = { version = "0.23", default-features = false, features = [
     "ring",


### PR DESCRIPTION
It depends on the manager version 0.42.0.
~This PR is in draft status because implementing a precedent task corresponding to [this commit](https://github.com/petabi/review-protocol/commit/07edf4dd23b8685a7d29a27510d3598898fc7d24) is required first.~
Close: #146