### PR TITLE
Fix Clippy warnings caused by rustc 1.86.0

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -83,7 +83,6 @@ impl Client {
                     Err(e) => {
                         error!("Failed to accept bidirectional stream: {:?}", e);
                         sleep(Duration::from_secs(SERVER_RETRY_INTERVAL)).await;
-                        continue;
                     }
                 },
                 Err(e) => {


### PR DESCRIPTION
## Related Issues
closes #184 
## PR Description
- Removed unnecessary continue statements inside loops to comply with Clippy's needless_continue lint introduced in Rust 1.86.0.

- If explicit continue is preferred for readability, it can be allowed by adding `#[allow(clippy::needless_continue)].`