### PR TITLE
Fix connection behavior after manager restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Fixed an issue where the connection to the manager was not re-established
-  after the manager restarted.
+- Fixed bugs where the connections to the manager and data-store were not
+  re-established after either application was restarted.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue where the connection to the manager was not re-established
+  after the manager restarted.
+
 ### Changed
 
 - Replaced the `log_dir` configuration option with `log_path`. The `log_path`


### PR DESCRIPTION
Update the `connect` method to properly check whether the existing connection has been closed before attempting to reuse it.

Closes #190