### PR TITLE
Upgrade `bincode` to v2 and update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   session's final timestamp instead of the session duration.
 - Updated `giganto-client` dependency to support type-driven stream
   requests, replacing `NodeType`-based handling with `StreamRequestPayload`
-  enum for improved API consistency.
+  enum for improved API consistency. This update also adds `start_time`
+  field to all protocol event structures.
+- Bump bincode crate to 2.0 and modified the related code.
 
 ## [0.6.4] - 2025-07-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ dependencies = [
  "anyhow",
  "async-channel",
  "async-trait",
- "bincode 1.3.3",
+ "bincode 2.0.1",
  "chrono",
  "clap",
  "config",
@@ -647,10 +647,10 @@ dependencies = [
 [[package]]
 name = "giganto-client"
 version = "0.23.0"
-source = "git+https://github.com/aicers/giganto-client.git?rev=8732528#8732528783c94b09b346fe78f5911313ee4eafab"
+source = "git+https://github.com/aicers/giganto-client.git?rev=47815ca#47815ca2ebdba920731f764ff413dbf7ad9a247a"
 dependencies = [
  "anyhow",
- "bincode 1.3.3",
+ "bincode 2.0.1",
  "chrono",
  "num_enum",
  "quinn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2024"
 anyhow = "1"
 async-channel = "2"
 async-trait = "0.1"
-bincode = "1"
+bincode = { version = "2", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 config = { version = "0.15", features = ["toml"], default-features = false }
-giganto-client = { git = "https://github.com/aicers/giganto-client.git", rev = "8732528" }
+giganto-client = { git = "https://github.com/aicers/giganto-client.git", rev = "47815ca" }
 num_enum = "0.7"
 num-traits = "0.2"
 quinn = { version = "0.11", features = ["ring"] }


### PR DESCRIPTION
## Description
- Migrate `bincode` v1 to v2 with `serde` feature
- Update `giganto-client` to rev `47815ca` (adds `start_time` field)

Closes: #232