### PR TITLE
Add test code for subscribe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,13 +33,13 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-[lints.clippy]
-pedantic = "warn"
-unwrap_used = "warn"
-
 [dev-dependencies]
+serial_test = "3"
 tempfile = "3"
 rcgen = { version = "0.14", features = ["pem", "x509-parser"] }
 time = "0.3"
 rstest = "0.26"
-serial_test = "3"
+
+[lints.clippy]
+pedantic = "warn"
+unwrap_used = "warn"

--- a/src/subscribe/tests.rs
+++ b/src/subscribe/tests.rs
@@ -1,73 +1,381 @@
-use std::cmp::Ordering;
-use std::sync::LazyLock;
+use std::collections::HashMap;
 use std::time::Duration;
 use std::{
-    collections::HashMap,
     fs,
     net::{IpAddr, Ipv6Addr, SocketAddr},
     path::{Path, PathBuf},
     sync::Arc,
 };
 
-use chrono::{DateTime, NaiveDate, Utc};
-use quinn::{Connection, Endpoint, ServerConfig, crypto::rustls::QuicServerConfig};
+use chrono::Utc;
+use giganto_client::{
+    connection::server_handshake,
+    frame::{recv_raw, send_bytes, send_raw},
+    ingest::receive_record_header,
+    publish::receive_stream_request,
+    publish::stream::StreamRequestPayload,
+};
+use quinn::{
+    Connection, Endpoint, RecvStream, SendStream, ServerConfig, crypto::rustls::QuicServerConfig,
+};
+use review_protocol::request::Handler;
 use review_protocol::types::{SamplingKind, SamplingPolicy};
-use tokio::sync::{Mutex, Notify, RwLock};
+use serial_test::serial;
+use tempfile::TempDir;
+use tokio::sync::Notify;
+use tokio::time::{sleep, timeout};
 
-use super::{Client, Conn, TimeSeries};
+use super::time_series::clear_last_transfer_time;
+use super::*;
 use crate::client::Certs;
-
-static TOKEN: LazyLock<Mutex<u32>> = LazyLock::new(|| Mutex::new(0));
 
 const CERT_PATH: &str = "tests/cert.pem";
 const KEY_PATH: &str = "tests/key.pem";
 const CA_CERT_PATH: &str = "tests/ca_cert.pem";
 const HOST: &str = "localhost";
-const TEST_INGEST_PORT: u16 = 60190;
-const TEST_PUBLISH_PORT: u16 = 60191;
-const PROTOCOL_VERSION: &str = "0.4.0";
-const LAST_TIME_SERIES_PATH: &str = "tests/time_data.json";
 const SECS_PER_MINUTE: u64 = 60;
 const SECS_PER_DAY: u64 = 86_400;
+const DEFAULT_POLICY_ID: u32 = 1;
 
-struct TestServer {
+struct FakeGigantoServer {
     server_config: ServerConfig,
     server_address: SocketAddr,
+    ingest_notify: Option<async_channel::Sender<u32>>,
+    publish_repeat_count: usize,
+    publish_repeat_delay: Duration,
 }
 
-impl TestServer {
-    fn new(port: u16) -> Self {
+struct TestServerHandlers {
+    ingest_shutdown: Arc<Notify>,
+    publish_shutdown: Arc<Notify>,
+    ingest_handle: tokio::task::JoinHandle<()>,
+    publish_handle: tokio::task::JoinHandle<()>,
+}
+
+impl FakeGigantoServer {
+    fn new_ingest() -> Self {
         let server_config = config_server();
-        let server_address = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), port);
-        TestServer {
+        let server_address = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0);
+        FakeGigantoServer {
             server_config,
             server_address,
+            ingest_notify: None,
+            publish_repeat_count: 0,
+            publish_repeat_delay: Duration::from_millis(0),
         }
     }
 
-    async fn run(self) {
+    fn new_publish() -> Self {
+        let server_config = config_server();
+        let server_address = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0);
+        FakeGigantoServer {
+            server_config,
+            server_address,
+            ingest_notify: None,
+            publish_repeat_count: 3,
+            publish_repeat_delay: Duration::from_millis(200),
+        }
+    }
+
+    fn with_notify(mut self, notify: async_channel::Sender<u32>) -> Self {
+        self.ingest_notify = Some(notify);
+        self
+    }
+
+    fn start_ingest(self, shutdown: Arc<Notify>) -> (SocketAddr, tokio::task::JoinHandle<()>) {
         let endpoint = Endpoint::server(self.server_config, self.server_address).expect("endpoint");
-        while let Some(conn) = endpoint.accept().await {
-            tokio::spawn(async move { handle_connection(conn).await });
+        let local_addr = endpoint.local_addr().expect("local_addr");
+        let ingest_notify = self.ingest_notify.clone();
+        let handle = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    Some(conn) = endpoint.accept() => {
+                        let notify = ingest_notify.clone();
+                        tokio::spawn(async move {
+                            if let Ok(connection) = conn.await {
+                                handle_ingest_connection(connection, notify).await;
+                            }
+                        });
+                    }
+                    () = shutdown.notified() => {
+                        endpoint.close(0u32.into(), &[]);
+                        break;
+                    }
+                }
+            }
+        });
+        (local_addr, handle)
+    }
+
+    fn start_publish(self, shutdown: Arc<Notify>) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+        let endpoint = Endpoint::server(self.server_config, self.server_address).expect("endpoint");
+        let local_addr = endpoint.local_addr().expect("local_addr");
+        let publish_repeat_count = self.publish_repeat_count;
+        let publish_repeat_delay = self.publish_repeat_delay;
+        let handle = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    Some(conn) = endpoint.accept() => {
+                        tokio::spawn(async move {
+                            if let Ok(connection) = conn.await {
+                                handle_publish_connection(
+                                    connection,
+                                    publish_repeat_count,
+                                    publish_repeat_delay,
+                                )
+                                .await;
+                            }
+                        });
+                    }
+                    () = shutdown.notified() => {
+                        endpoint.close(0u32.into(), &[]);
+                        break;
+                    }
+                }
+            }
+        });
+        (local_addr, handle)
+    }
+}
+
+async fn handle_ingest_connection(
+    connection: Connection,
+    notify: Option<async_channel::Sender<u32>>,
+) {
+    let version_req = format!("={REQUIRED_GIGANTO_VERSION}");
+    if server_handshake(&connection, &version_req).await.is_err() {
+        return;
+    }
+
+    while let Ok((send, recv)) = connection.accept_bi().await {
+        let notify = notify.clone();
+        tokio::spawn(async move {
+            handle_ingest_stream(send, recv, notify).await;
+        });
+    }
+}
+
+async fn handle_publish_connection(
+    connection: Connection,
+    repeat_count: usize,
+    repeat_delay: Duration,
+) {
+    let version_req = format!("={REQUIRED_GIGANTO_VERSION}");
+    let Ok((_send, mut recv)) = server_handshake(&connection, &version_req).await else {
+        return;
+    };
+
+    loop {
+        let Ok(payload) = receive_stream_request(&mut recv).await else {
+            break;
+        };
+        let (policy_id, record_bytes) = match payload {
+            StreamRequestPayload::TimeSeriesGenerator { request, .. } => {
+                (request.id, bincode::serialize(&gen_conn()).unwrap())
+            }
+            _ => continue,
+        };
+
+        let Ok(mut uni) = connection.open_uni().await else {
+            continue;
+        };
+        let _ = send_raw(&mut uni, policy_id.as_bytes()).await;
+
+        for idx in 0..repeat_count {
+            let ts = Utc::now().timestamp_nanos_opt().unwrap_or(i64::MAX);
+            let _ = send_bytes(&mut uni, &ts.to_le_bytes()).await;
+            let _ = send_raw(&mut uni, &record_bytes).await;
+            if idx + 1 < repeat_count {
+                sleep(repeat_delay).await;
+            }
+        }
+        let _ = uni.finish();
+    }
+}
+
+async fn handle_ingest_stream(
+    mut send: SendStream,
+    mut recv: RecvStream,
+    notify: Option<async_channel::Sender<u32>>,
+) {
+    let mut header_buf = [0_u8; 4];
+    if receive_record_header(&mut recv, &mut header_buf)
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    let mut buf = Vec::new();
+    if recv_raw(&mut recv, &mut buf).await.is_err() {
+        return;
+    }
+
+    if let Ok(batch) = bincode::deserialize::<Vec<(i64, Vec<u8>)>>(&buf) {
+        let policy_id = batch
+            .first()
+            .and_then(|(_, payload)| bincode::deserialize::<TimeSeries>(payload).ok())
+            .and_then(|series| series.sampling_policy_id.parse::<u32>().ok())
+            .unwrap_or(0);
+        for (timestamp, _) in batch {
+            if send_bytes(&mut send, &timestamp.to_be_bytes())
+                .await
+                .is_err()
+            {
+                return;
+            }
+            if let Some(notify) = &notify {
+                let _ = notify.send(policy_id).await;
+            }
         }
     }
 }
 
-async fn handle_connection(conn: quinn::Incoming) {
-    let connection = conn.await.unwrap();
-    connection_handshake(&connection).await;
+fn start_servers() -> (
+    async_channel::Receiver<u32>,
+    TestServerHandlers,
+    SocketAddr,
+    SocketAddr,
+) {
+    let (ingest_ack_send, ingest_ack_recv) = async_channel::bounded::<u32>(10);
+    let ingest_server = FakeGigantoServer::new_ingest().with_notify(ingest_ack_send);
+    let publish_server = FakeGigantoServer::new_publish();
+    let ingest_shutdown = Arc::new(Notify::new());
+    let publish_shutdown = Arc::new(Notify::new());
+    let (ingest_addr, ingest_handle) = ingest_server.start_ingest(ingest_shutdown.clone());
+    let (publish_addr, publish_handle) = publish_server.start_publish(publish_shutdown.clone());
+    (
+        ingest_ack_recv,
+        TestServerHandlers {
+            ingest_shutdown,
+            publish_shutdown,
+            ingest_handle,
+            publish_handle,
+        },
+        ingest_addr,
+        publish_addr,
+    )
+}
 
-    let conn_event = gen_conn();
-    let conn_raw_event = bincode::serialize(&conn_event).unwrap();
-    let conn_len = u32::try_from(conn_raw_event.len()).unwrap().to_le_bytes();
+fn setup_request_client(
+    buffer: usize,
+) -> (
+    crate::request::Client,
+    async_channel::Receiver<SamplingPolicy>,
+    PathBuf,
+    TempDir,
+) {
+    let (request_send, request_recv) = async_channel::bounded::<SamplingPolicy>(buffer);
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let last_time_series_path = temp_dir.path().join("time_data.json");
+    let request_client = crate::request::Client::new(
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0),
+        HOST.to_string(),
+        request_send,
+        fs::read(CERT_PATH).unwrap(),
+        fs::read(KEY_PATH).unwrap(),
+        vec![fs::read(CA_CERT_PATH).unwrap()],
+        Arc::new(Notify::new()),
+    );
+    (
+        request_client,
+        request_recv,
+        last_time_series_path,
+        temp_dir,
+    )
+}
 
-    let (mut send, _) = connection.accept_bi().await.unwrap();
-    let ts = Utc::now().timestamp_nanos_opt().unwrap_or(i64::MAX);
-    let mut send_buf: Vec<u8> = Vec::new();
-    send_buf.extend(ts.to_le_bytes());
-    send_buf.extend(conn_len);
-    send_buf.extend_from_slice(&conn_raw_event);
-    send.write_all(&send_buf).await.unwrap();
+fn new_policy(id: u32) -> SamplingPolicy {
+    SamplingPolicy {
+        id,
+        kind: SamplingKind::Conn,
+        interval: Duration::from_secs(15 * SECS_PER_MINUTE),
+        period: Duration::from_secs(SECS_PER_DAY),
+        offset: 0,
+        src_ip: None,
+        dst_ip: None,
+        node: Some("cluml".to_string()),
+        column: None,
+    }
+}
+
+fn spawn_subscribe_client(
+    certs: &Certs,
+    request_recv: async_channel::Receiver<SamplingPolicy>,
+    last_time_series_path: &Path,
+    ingest_addr: SocketAddr,
+    publish_addr: SocketAddr,
+    request_client: &crate::request::Client,
+) -> (tokio::task::JoinHandle<()>, Arc<Notify>) {
+    let client = Client::new(
+        ingest_addr,
+        publish_addr,
+        HOST.to_string(),
+        last_time_series_path.to_path_buf(),
+        certs,
+        request_recv,
+    );
+
+    let client_shutdown = Arc::new(Notify::new());
+    let client_shutdown_clone = client_shutdown.clone();
+    let active_policy_list = request_client.active_policy_list.clone();
+    let delete_policy_ids = request_client.delete_policy_ids.clone();
+
+    let client_handle = tokio::spawn(async move {
+        let _ = client
+            .run(active_policy_list, delete_policy_ids, client_shutdown_clone)
+            .await;
+    });
+
+    (client_handle, client_shutdown)
+}
+
+async fn reset_last_transfer_time() {
+    clear_last_transfer_time().await;
+}
+
+async fn wait_for_policy_ids(
+    last_time_series_path: &Path,
+    ids: &[u32],
+    should_exist: bool,
+) -> HashMap<String, i64> {
+    loop {
+        if last_time_series_path.exists() {
+            let map = read_time_data_map(last_time_series_path);
+            if ids
+                .iter()
+                .all(|id| map.contains_key(&id.to_string()) == should_exist)
+            {
+                return map;
+            }
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn cleanup_test_resources(
+    client_shutdown: Arc<Notify>,
+    client_handle: tokio::task::JoinHandle<()>,
+    server_handles: TestServerHandlers,
+) {
+    client_shutdown.notify_one();
+    server_handles.ingest_shutdown.notify_one();
+    server_handles.publish_shutdown.notify_one();
+
+    let _ = tokio::join!(
+        client_handle,
+        server_handles.ingest_handle,
+        server_handles.publish_handle
+    );
+    INGEST_CHANNEL.write().await.clear();
+}
+
+fn read_time_data_map(last_time_series_path: &Path) -> HashMap<String, i64> {
+    let content = fs::read_to_string(last_time_series_path).unwrap_or_default();
+    if content.trim().is_empty() {
+        return HashMap::new();
+    }
+    serde_json::from_str::<HashMap<String, i64>>(&content).expect("Failed to parse time_data.json")
 }
 
 fn config_server() -> ServerConfig {
@@ -94,20 +402,6 @@ fn config_server() -> ServerConfig {
     server_config
 }
 
-fn client() -> Client {
-    let certs = cert_key();
-    let (_, rx) = async_channel::unbounded();
-
-    Client::new(
-        SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), TEST_INGEST_PORT),
-        SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), TEST_PUBLISH_PORT),
-        String::from(HOST),
-        PathBuf::from(LAST_TIME_SERIES_PATH),
-        &certs,
-        rx,
-    )
-}
-
 fn cert_key() -> Certs {
     let cert_pem = fs::read(CERT_PATH).unwrap();
     let cert = Certs::to_cert_chain(&cert_pem).unwrap();
@@ -122,62 +416,6 @@ fn cert_key() -> Certs {
         key: key.clone_key(),
         ca_certs: ca_certs.clone(),
     }
-}
-
-async fn connection_handshake(conn: &Connection) {
-    let (mut send, mut recv) = conn
-        .open_bi()
-        .await
-        .expect("Failed to open bidirectional channel");
-    let version_len = u64::try_from(PROTOCOL_VERSION.len())
-        .expect("less than u64::MAX")
-        .to_le_bytes();
-
-    let mut handshake_buf = Vec::with_capacity(version_len.len() + PROTOCOL_VERSION.len());
-    handshake_buf.extend(version_len);
-    handshake_buf.extend(PROTOCOL_VERSION.as_bytes());
-    send.write_all(&handshake_buf)
-        .await
-        .expect("Failed to send handshake data");
-    let mut resp_len_buf = [0; std::mem::size_of::<u64>()];
-    recv.read_exact(&mut resp_len_buf)
-        .await
-        .expect("Failed to receive handshake data");
-    let len = u64::from_le_bytes(resp_len_buf);
-
-    let mut resp_buf = vec![0; len.try_into().expect("Failed to convert data type")];
-    recv.read_exact(resp_buf.as_mut_slice()).await.unwrap();
-
-    bincode::deserialize::<Option<&str>>(&resp_buf)
-        .expect("Failed to deserialize recv data")
-        .expect("Incompatible version");
-}
-
-fn test_conn_model() -> (SamplingPolicy, TimeSeries) {
-    (
-        SamplingPolicy {
-            id: 0,
-            kind: SamplingKind::Conn,
-            interval: Duration::from_secs(15 * SECS_PER_MINUTE),
-            period: Duration::from_secs(SECS_PER_DAY),
-            offset: 32_400,
-            src_ip: None,
-            dst_ip: None,
-            node: Some("cluml".to_string()),
-            column: None,
-        },
-        TimeSeries {
-            sampling_policy_id: "0".to_string(),
-            start: DateTime::<Utc>::from_naive_utc_and_offset(
-                NaiveDate::from_ymd_opt(2022, 11, 17)
-                    .unwrap()
-                    .and_hms_opt(0, 0, 0)
-                    .unwrap(),
-                Utc,
-            ),
-            series: vec![0_f64; 96],
-        },
-    )
 }
 
 fn gen_conn() -> Conn {
@@ -202,142 +440,217 @@ fn gen_conn() -> Conn {
     }
 }
 
-// test만들다가 현재 test할 기능이 없어 쓰지 않지만
-// 추가적으로 기능 구현할 때 수정하여 쓸수 있게 일단 남겨두었습니다.
-// #[tokio::test]
-#[allow(unused)]
-async fn connect() {
-    let _lock = TOKEN.lock().await;
-    let ingest_server = TestServer::new(TEST_INGEST_PORT);
-    let publish_server = TestServer::new(TEST_PUBLISH_PORT);
-    tokio::spawn(ingest_server.run());
-    tokio::spawn(publish_server.run());
-    client()
-        .run(
-            Arc::new(RwLock::new(HashMap::new())),
-            Arc::new(RwLock::new(Vec::new())),
-            Arc::new(Notify::new()),
-        )
-        .await;
-}
-
+#[serial]
 #[tokio::test]
-async fn ingest_connection_control_returns_cert_error_on_server_name_mismatch() {
-    let _lock = TOKEN.lock().await;
-    tokio::spawn(TestServer::new(TEST_INGEST_PORT).run());
-    tokio::time::sleep(Duration::from_millis(50)).await;
+async fn sampling_policy_flow_with_fake_giganto_server() {
+    reset_last_transfer_time().await;
+    // Arrange: start fake servers and a request client.
+    let (ingest_ack_recv, server_handles, ingest_addr, publish_addr) = start_servers();
 
     let certs = cert_key();
-    let endpoint = crate::client::config(&certs).expect("client endpoint");
-    let (_series_sender, series_receiver) = async_channel::bounded::<TimeSeries>(1);
+    let (mut request_client, request_recv, last_time_series_path, _temp_dir) =
+        setup_request_client(1);
 
-    let result = tokio::time::timeout(
-        Duration::from_secs(3),
-        super::ingest_connection_control(
-            series_receiver,
-            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), TEST_INGEST_PORT),
-            "mismatched-server-name",
-            &endpoint,
-            Path::new(LAST_TIME_SERIES_PATH),
-            PROTOCOL_VERSION,
-            Arc::new(Notify::new()),
-        ),
-    )
-    .await
-    .expect("No timeout");
+    let policy = new_policy(DEFAULT_POLICY_ID);
 
-    endpoint.close(0u32.into(), &[]);
+    // Act: insert policy into request client.
+    request_client
+        .sampling_policy_list(std::slice::from_ref(&policy))
+        .await
+        .unwrap();
 
-    let err = result.expect_err("Connection should fail on invalid peer certificate");
+    // Assert: policy is tracked in the active list.
     assert!(
-        err.to_string()
-            .contains("Invalid peer certificate contents"),
-        "Unexpected error: {err:#}"
-    );
-}
-
-#[tokio::test]
-async fn publish_connection_control_returns_cert_error_on_server_name_mismatch() {
-    let _lock = TOKEN.lock().await;
-    tokio::spawn(TestServer::new(TEST_PUBLISH_PORT).run());
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
-    let certs = cert_key();
-    let endpoint = crate::client::config(&certs).expect("client endpoint");
-    let (series_sender, _series_receiver) = async_channel::bounded::<TimeSeries>(1);
-    let (_request_sender, request_receiver) = async_channel::bounded::<SamplingPolicy>(1);
-
-    let result = tokio::time::timeout(
-        Duration::from_secs(3),
-        super::publish_connection_control(
-            series_sender,
-            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), TEST_PUBLISH_PORT),
-            "mismatched-server-name",
-            &endpoint,
-            PROTOCOL_VERSION,
-            &request_receiver,
-            Arc::new(RwLock::new(HashMap::new())),
-            Arc::new(RwLock::new(Vec::new())),
-            Path::new(LAST_TIME_SERIES_PATH),
-            Arc::new(Notify::new()),
-        ),
-    )
-    .await
-    .expect("No timeout");
-
-    endpoint.close(0u32.into(), &[]);
-
-    let err = result.expect_err("Connection should fail on invalid peer certificate");
-    assert!(
-        err.to_string()
-            .contains("Invalid peer certificate contents"),
-        "Unexpected error: {err:#}"
-    );
-}
-
-// start time: 2022/11/17 00:00:00
-// input time: 2022/11/17 00:03:00 + 3min for loop
-// interval: 15min
-// period: 1day
-#[tokio::test]
-async fn timeseries_with_conn() {
-    use crate::subscribe::TimeSeries;
-    const THREE_MIN: i64 = 3;
-
-    let (model, mut timeseries) = test_conn_model();
-    let mut min: i64 = 3;
-    let (sender, _receiver) = async_channel::bounded::<TimeSeries>(1);
-
-    while min < 10 {
-        // 3times
-        let conn_event = gen_conn();
-        let dur = chrono::TimeDelta::try_minutes(min).unwrap();
-
-        let time = DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDate::from_ymd_opt(2022, 11, 17)
-                .unwrap()
-                .and_hms_opt(0, 0, 0)
-                .unwrap()
-                .checked_add_signed(dur)
-                .unwrap(),
-            Utc,
-        );
-
-        timeseries
-            .fill(
-                &model,
-                time,
-                &crate::subscribe::Event::Conn(conn_event),
-                &sender,
-            )
+        request_client
+            .active_policy_list
+            .read()
             .await
-            .unwrap();
-
-        min += THREE_MIN;
-    }
-
-    assert_eq!(
-        timeseries.series[36].partial_cmp(&3.0),
-        Some(Ordering::Equal),
+            .contains_key(&policy.id)
     );
+
+    let (client_handle, client_shutdown) = spawn_subscribe_client(
+        &certs,
+        request_recv,
+        &last_time_series_path,
+        ingest_addr,
+        publish_addr,
+        &request_client,
+    );
+
+    // Act/Assert: wait for ingest ACK and timestamp file creation.
+    let id = timeout(Duration::from_secs(5), ingest_ack_recv.recv())
+        .await
+        .expect("Ingest ACK should arrive within 5s after adding sampling policy")
+        .expect("Ingest ACK channel should remain open until ACK is received after adding sampling policy");
+    assert_eq!(id, policy.id);
+
+    let map = timeout(
+        Duration::from_secs(5),
+        wait_for_policy_ids(&last_time_series_path, &[policy.id], true),
+    )
+    .await
+    .expect("No timeout: expected policy ID was written to time_data.json");
+
+    assert!(last_time_series_path.exists());
+    let expected: HashMap<String, i64> = [(policy.id.to_string(), 0)].into_iter().collect();
+    assert_eq!(map, expected);
+
+    // Cleanup: stop client and servers.
+    cleanup_test_resources(client_shutdown, client_handle, server_handles).await;
+}
+
+/// Test: Validates notify flow - when a policy is added, the client sends a stream
+/// request and receives data from the server. When the policy is deleted, the stream
+/// should be stopped and timestamp cleaned up.
+#[serial]
+#[tokio::test]
+async fn sampling_policy_notify_flow_with_delete() {
+    reset_last_transfer_time().await;
+    // Arrange: start servers and request client.
+    let (ingest_ack_recv, server_handles, ingest_addr, publish_addr) = start_servers();
+
+    let certs = cert_key();
+    let (mut request_client, request_recv, last_time_series_path, _temp_dir) =
+        setup_request_client(1);
+    let policy = new_policy(DEFAULT_POLICY_ID);
+
+    // Act: insert policy.
+    request_client
+        .sampling_policy_list(std::slice::from_ref(&policy))
+        .await
+        .unwrap();
+
+    // Assert: policy is tracked in the active list.
+    assert!(
+        request_client
+            .active_policy_list
+            .read()
+            .await
+            .contains_key(&policy.id)
+    );
+
+    let (client_handle, client_shutdown) = spawn_subscribe_client(
+        &certs,
+        request_recv,
+        &last_time_series_path,
+        ingest_addr,
+        publish_addr,
+        &request_client,
+    );
+
+    // Act/Assert: wait for ingest ACK and timestamp file creation.
+    let id = timeout(Duration::from_secs(5), ingest_ack_recv.recv())
+        .await
+        .expect("Ingest ACK should arrive within 5s after adding sampling policy")
+        .expect("Ingest ACK channel should remain open until ACK is received after adding sampling policy");
+    assert_eq!(id, policy.id);
+
+    let map = timeout(
+        Duration::from_secs(5),
+        wait_for_policy_ids(&last_time_series_path, &[policy.id], true),
+    )
+    .await
+    .expect("No timeout: expected policy ID was written to time_data.json");
+
+    assert!(last_time_series_path.exists());
+    let expected: HashMap<String, i64> = [(policy.id.to_string(), 0)].into_iter().collect();
+    assert_eq!(map, expected);
+
+    // Act: delete policy.
+    request_client
+        .delete_sampling_policy(&[policy.id])
+        .await
+        .unwrap();
+
+    // Assert: timestamp entry is removed after deletion.
+    let map = timeout(
+        Duration::from_secs(5),
+        wait_for_policy_ids(&last_time_series_path, &[policy.id], false),
+    )
+    .await
+    .expect("No timeout: expected policy ID was removed from time_data.json");
+
+    assert!(last_time_series_path.exists());
+    let expected: HashMap<String, i64> = HashMap::new();
+    assert_eq!(map, expected);
+
+    // Cleanup: stop client and servers.
+    cleanup_test_resources(client_shutdown, client_handle, server_handles).await;
+}
+
+/// Test: Adding multiple policies should create multiple concurrent streams.
+#[serial]
+#[tokio::test]
+async fn sampling_policy_multiple_streams() {
+    reset_last_transfer_time().await;
+    // Arrange: start servers and request client with two policies.
+    let (ingest_ack_recv, server_handles, ingest_addr, publish_addr) = start_servers();
+
+    let certs = cert_key();
+    let (mut request_client, request_recv, last_time_series_path, _temp_dir) =
+        setup_request_client(2);
+    let policy_a = new_policy(1);
+    let policy_b = new_policy(2);
+
+    // Act: insert two policies.
+    request_client
+        .sampling_policy_list(&[policy_a.clone(), policy_b.clone()])
+        .await
+        .unwrap();
+
+    // Assert: both policies are active.
+    assert!(
+        request_client
+            .active_policy_list
+            .read()
+            .await
+            .contains_key(&policy_a.id)
+    );
+    assert!(
+        request_client
+            .active_policy_list
+            .read()
+            .await
+            .contains_key(&policy_b.id)
+    );
+
+    let (client_handle, client_shutdown) = spawn_subscribe_client(
+        &certs,
+        request_recv,
+        &last_time_series_path,
+        ingest_addr,
+        publish_addr,
+        &request_client,
+    );
+
+    // Act/Assert: receive policy IDs for both streams.
+    let mut expected_ids = vec![policy_a.id, policy_b.id];
+    for _ in 0..2 {
+        let id = timeout(Duration::from_secs(5), ingest_ack_recv.recv())
+            .await
+            .expect("Ingest ACKs for all sampling policies should arrive within 5s")
+            .expect("Ingest ACK channel should remain open until ACKs for all sampling policies are received");
+        expected_ids.retain(|expected| *expected != id);
+    }
+    assert!(
+        expected_ids.is_empty(),
+        "Not all policy IDs produced streams: {expected_ids:?}"
+    );
+
+    let map = timeout(
+        Duration::from_secs(5),
+        wait_for_policy_ids(&last_time_series_path, &[policy_a.id, policy_b.id], true),
+    )
+    .await
+    .expect("No timeout: expected policy IDs were written to time_data.json");
+
+    assert!(last_time_series_path.exists());
+    let expected: HashMap<String, i64> =
+        [(policy_a.id.to_string(), 0), (policy_b.id.to_string(), 0)]
+            .into_iter()
+            .collect();
+    assert_eq!(map, expected);
+
+    // Cleanup: stop client and servers.
+    cleanup_test_resources(client_shutdown, client_handle, server_handles).await;
 }


### PR DESCRIPTION
Close: #267 
**Added new integration tests:**
* `sampling_policy_flow_with_fake_giganto_server`: Validates the basic flow of policy registration and data reception.
* `sampling_policy_notify_flow_with_delete`: Verifies stream termination and local file cleanup upon policy deletion.
* `sampling_policy_multiple_streams`: Ensures individual streams operate correctly when multiple policies are active simultaneously.

**Enhanced test readability:**
* `timeseries_with_conn`: Now validates that multiple Conn events within the same 15-minute slot are correctly aggregated.