### PR TITLE
Temporarily ignore `run_clears_state_on_start`

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -937,6 +937,7 @@ mod tests {
     // =========================================================================
 
     #[tokio::test(flavor = "current_thread")]
+    #[ignore = "Temporarily ignored: fix together with issue #290 (runtime exit path may terminate test process)"]
     async fn run_clears_state_on_start() {
         // Test: run() should clear active_policy_list and delete_policy_ids on start
         let (mut client, rx) = create_test_client();


### PR DESCRIPTION
Add an ignore annotation to the `run_clears_state_on_start` test to prevent intermittent termination of the test process during coverage runs. This change is a temporary mitigation until issue #290 is resolved.

Closes #291