### PR TITLE
Run the Markdown lint on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,12 @@ jobs:
 
   check:
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    # Fail closed. A bare `docs_only != 'true'` lets a *failing* `changes` job
+    # skip its dependants, and GitHub counts a skipped required check as a
+    # pass -- so a broken filter would wave an untested change through.
+    # `!cancelled()` runs the job whenever the filter did not positively
+    # report docs-only, a failed filter included.
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true') }}
     runs-on: ubuntu-latest
     steps:
       - name: Install Rust
@@ -58,6 +63,16 @@ jobs:
         run: cargo clippy --tests -- -D warnings
       - name: Detect Cargo.lock changes
         run: git diff-index --quiet HEAD --
+
+  # Ungated, deliberately. This used to be the last step of `check`, which is
+  # gated on the path filter -- so a docs-only change skipped `check` and took
+  # the Markdown lint down with it. The one change that most needs this lint
+  # was the one change that did not get it.
+  markdown:
+    name: Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
       - name: markdownlint
         uses: DavidAnson/markdownlint-cli2-action@v23
         with:
@@ -65,7 +80,12 @@ jobs:
 
   test:
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    # Fail closed. A bare `docs_only != 'true'` lets a *failing* `changes` job
+    # skip its dependants, and GitHub counts a skipped required check as a
+    # pass -- so a broken filter would wave an untested change through.
+    # `!cancelled()` runs the job whenever the filter did not positively
+    # report docs-only, a failed filter included.
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true') }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Closes #356.

## Two problems, same place

**1. The Markdown lint disappears exactly when it is needed.** `markdownlint` was the last step of `check`, and `check` is gated on the `changes` path filter. A documentation-only change skips `check` — and takes the lint with it. The one kind of change that most needs a Markdown lint was the one kind that did not get one.

**2. The gate fails open.** The condition was a bare `if: needs.changes.outputs.docs_only != 'true'`. When a `needs:` dependency *fails*, GitHub skips its dependants, and counts a skipped required check as a pass. A `changes` job that errored would have silently waved an untested change through. `aicers/bootler` documents this hazard in `.github/actions/change-scope/action.yml`.

## The change

- `markdownlint` lifted into a standalone `markdown` job (display name `Markdown`), ungated, matching the shape `aicers/roxyd` and `aicers/agentcoop` already use. The action, its pinned version, and its existing recursive `globs: '**/*.md'` are untouched.
- Both gated jobs (`check`, `test`) now carry:

  ```yaml
  if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true') }}
  ```

  `!cancelled()` runs the job whenever the filter did not *positively* report docs-only — a failed filter included.

## Verification

- The existing glob was already recursive; `markdownlint-cli2@0.22.1` run against `main` locally reports **0 errors** across all 12 files, so nothing new is being caught.
- Branch protection on `main` requires **no status checks** (only one approving review), so the new `Markdown` job needs no protection change and the moved step breaks nothing.
- `actionlint` (with shellcheck) is clean.

## Relationship to the other open pull request

There is a separate pull request in this repository scoping the CI triggers. The two touch different parts of `ci.yml` and were tested to merge cleanly in either order (`git merge-tree`, no conflict).

## Out of scope

- Upgrading the action, editing Markdown content, CI triggers.
