### PR TITLE
Update markdownlint-cli2-action to v24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v23
+        uses: DavidAnson/markdownlint-cli2-action@v24
         with:
           globs: '**/*.md'
 


### PR DESCRIPTION
Closes #358

Bumps the Markdown linter from `@v23` to `@v24`, the current release, which bundles markdownlint 0.41.1. Configuration and globs are unchanged.

Four different tags of this action are in use across the organisation, so the same document can pass in one repository and fail in another. MD056 (table column count), added since the older tags, catches a real defect class: a `|` inside a code span splits a table cell and the data disappears from the rendered table.

**Verification**: markdownlint-cli2 0.23.2 against this branch with the repository's own configuration and CI globs — 12 files linted, `0 issues`, exit 0.